### PR TITLE
Add shared gRPC error translation utilities

### DIFF
--- a/internal/product/interfaces/grpc/grpc.go
+++ b/internal/product/interfaces/grpc/grpc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smallbiznis/smallbiznis-apps/internal/product/domain"
 	"github.com/smallbiznis/smallbiznis-apps/internal/product/usecase"
 	"github.com/smallbiznis/smallbiznis-apps/pkg/db/pagination"
+	"github.com/smallbiznis/smallbiznis-apps/pkg/errutil"
 	"go.uber.org/fx"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -33,7 +34,7 @@ func NewProductHandler(p Params) *ProductHandler {
 func (h *ProductHandler) CreateProduct(ctx context.Context, req *productv1.CreateProductRequest) (*productv1.Product, error) {
 	product, err := h.productUsecase.CreateProduct(ctx, req)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, errutil.ToGRPCError(err)
 	}
 
 	return product.ToProto(), nil
@@ -47,7 +48,7 @@ func (h *ProductHandler) GetProduct(ctx context.Context, req *productv1.GetProdu
 
 	product, err := h.productUsecase.GetProduct(ctx, productID.Int64())
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, errutil.ToGRPCError(err)
 	}
 
 	return &productv1.GetProductResponse{
@@ -59,7 +60,7 @@ func (h *ProductHandler) ListProducts(ctx context.Context, req *productv1.ListPr
 
 	orgID, err := snowflake.ParseString(req.OrgId)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	products, count, err := h.productUsecase.ListProduct(ctx, domain.Product{
@@ -68,7 +69,7 @@ func (h *ProductHandler) ListProducts(ctx context.Context, req *productv1.ListPr
 		Limit: int(req.Limit),
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, errutil.ToGRPCError(err)
 	}
 
 	return &productv1.ListProductsResponse{

--- a/pkg/errutil/error.go
+++ b/pkg/errutil/error.go
@@ -20,6 +20,10 @@ type BaseError struct {
 	Err     error      `json:"-"`
 }
 
+func (e BaseError) Status() CoreStatus {
+	return e.Code
+}
+
 func (e BaseError) URL() string {
 	values := url.Values{}
 
@@ -34,15 +38,10 @@ func (e BaseError) URL() string {
 }
 
 func (e BaseError) JSON() interface{} {
-	msg := e.Message
-	if e.Err != nil {
-		msg = fmt.Sprintf("%s: %v", e.Message, e.Err)
-	}
-
 	return map[string]interface{}{
 		"error": gin.H{
 			"code":    e.Code,
-			"message": msg,
+			"message": e.messageWithErr(),
 			"details": e.Details,
 		},
 	}
@@ -54,9 +53,16 @@ func (e BaseError) Unwrap() error {
 
 func (e BaseError) Error() string {
 	if e.Err != nil {
-		return fmt.Sprintf("[%s] %s: %v", e.Code, e.Message, e.Err)
+		return fmt.Sprintf("[%s] %s", e.Code, e.messageWithErr())
 	}
 	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+func (e BaseError) messageWithErr() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
 }
 
 type Option func(*BaseError)

--- a/pkg/errutil/grpc.go
+++ b/pkg/errutil/grpc.go
@@ -1,0 +1,75 @@
+package errutil
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GRPCCode converts the CoreStatus to its closest gRPC status code equivalent.
+func (s CoreStatus) GRPCCode() codes.Code {
+	switch s {
+	case StatusUnauthorized:
+		return codes.Unauthenticated
+	case StatusForbidden:
+		return codes.PermissionDenied
+	case StatusNotFound:
+		return codes.NotFound
+	case StatusTimeout, StatusGatewayTimeout:
+		return codes.DeadlineExceeded
+	case StatusUnprocessableEntity:
+		return codes.FailedPrecondition
+	case StatusUnsupportedMediaType, StatusBadRequest, StatusValidationFailed:
+		return codes.InvalidArgument
+	case StatusConflict:
+		return codes.AlreadyExists
+	case StatusTooManyRequests:
+		return codes.ResourceExhausted
+	case StatusClientClosedRequest:
+		return codes.Canceled
+	case StatusNotImplemented:
+		return codes.Unimplemented
+	case StatusBadGateway, StatusServiceUnavailable:
+		return codes.Unavailable
+	case StatusInternal:
+		return codes.Internal
+	case StatusUnknown:
+		return codes.Unknown
+	default:
+		return codes.Unknown
+	}
+}
+
+// ToGRPCError normalises a domain error into a gRPC status error so handlers can
+// safely return it to the transport layer.
+func ToGRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, err.Error())
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	}
+
+	var base BaseError
+	if errors.As(err, &base) {
+		return status.Error(base.Code.GRPCCode(), base.messageWithErr())
+	}
+
+	var coder interface{ Status() CoreStatus }
+	if errors.As(err, &coder) {
+		return status.Error(coder.Status().GRPCCode(), err.Error())
+	}
+
+	return status.Error(codes.Internal, err.Error())
+}


### PR DESCRIPTION
## Summary
- add CoreStatus to gRPC status code mapping and a helper to normalise errors returned by gRPC handlers
- expose BaseError.Status and reuse its formatted message so transport layers can inspect structured errors
- switch the product gRPC handler to share the common error converter

## Testing
- `go test ./...` *(fails: module downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d567968ee88326b6701d2ec7e96eec